### PR TITLE
fix: Default base_url protocol to http:// if missing

### DIFF
--- a/docs/point_of_presence_tutorial.ipynb
+++ b/docs/point_of_presence_tutorial.ipynb
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,9 +163,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Failed to register organization.\n",
+      "Error creating organization: Organization name already exists\n"
+     ]
+    }
+   ],
    "source": [
     "organization_data = {\n",
     "    \"name\": \"example_org\",  # Unique identifier for the organization\n",
@@ -204,9 +213,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All organizations: ['example_org', 'nsfsage', 'on-demand_fakequakes', 'earthscope_consortium', 'nasa', 'sage1', 'test_organization', 'usda']\n"
+     ]
+    }
+   ],
    "source": [
     "# List all organizations without filtering\n",
     "try:\n",
@@ -226,9 +243,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Filtered organizations: ['example_org']\n"
+     ]
+    }
+   ],
    "source": [
     "# List organizations with a filter by name\n",
     "try:\n",
@@ -658,9 +683,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Search Results: [{'id': '86a6103f-acbf-492b-8d3f-2c679561e8db', 'name': 'testing-deleteme-data-20240304-184605-metadata', 'title': 'testing_deleteme_data_20240304_184605.metadata', 'owner_org': 'nsfsage', 'notes': 'Automatically generated metadata for sensor data', 'resources': [], 'extras': {'dcat:accrualPeriodicity': 'http://purl.org/linked-data/sdmx/2009/code#freq-D', 'dcat:contactPoint': '{\"fn\": \"Contact Name\", \"hasEmail\": \"mailto:contact@example.com\"}', 'dcat:distribution': 'URL: http://ds2.datacollaboratory.org/sage/testing_deleteme_data_20240304_184605.metadata, MediaType: application/json', 'dcat:keyword': 'Wind, Aerology, Meteorology', 'dcat:landingPage': 'http://example.com/landing-page-for-dataset', 'dcat:theme': 'http://eurovoc.europa.eu/561, http://eurovoc.europa.eu/273', 'dct:accessRights': 'Public', 'dct:conformsTo': 'http://example.com/standard', 'dct:created': '2024-03-04T18:46:41.282756', 'dct:creator': 'Your Organization or Name', 'dct:description': 'Dataset for wxt.wind.direction sensor data.', 'dct:identifier': '000048b02dd3c51f-wxt.wind.direction-vaisala-wxt536', 'dct:issued': '2024-03-04T18:46:41.282738', 'dct:language': 'en', 'dct:license': 'http://example.com/license', 'dct:modified': '2024-03-04T18:46:41.282761', 'dct:provenance': 'Generated from sensor network', 'dct:publisher': '{\"foaf:name\": \"Publisher Name\", \"foaf:homepage\": \"http://publisher-website.com\"}', 'dct:relation': '[\"http://example.com/related/resource1\", \"http://example.com/related/resource2\"]', 'dct:rights': 'http://creativecommons.org/licenses/by/4.0/', 'dct:source': 'Sensor Data Source or Origin', 'dct:spatial': 'lat: None, long: None', 'dct:subject': 'Weather Data, Environmental Data', 'dct:temporal': 'start: 2024-03-04T18:46:31.119280646Z, end: 2024-03-04T18:46:31.119280646Z', 'dct:title': 'wxt.wind.direction', 'dct:type': 'Dataset'}}, {'id': 'a7c18dd5-0762-4d62-9e95-d224f12d528c', 'name': 'testing-deleteme-data-20240304-184529-metadata', 'title': 'testing_deleteme_data_20240304_184529.metadata', 'owner_org': 'nsfsage', 'notes': 'Automatically generated metadata for sensor data', 'resources': [], 'extras': {'dcat:accrualPeriodicity': 'http://purl.org/linked-data/sdmx/2009/code#freq-D', 'dcat:contactPoint': '{\"fn\": \"Contact Name\", \"hasEmail\": \"mailto:contact@example.com\"}', 'dcat:distribution': 'URL: http://ds2.datacollaboratory.org/sage/testing_deleteme_data_20240304_184529.metadata, MediaType: application/json', 'dcat:keyword': 'Wind, Aerology, Meteorology', 'dcat:landingPage': 'http://example.com/landing-page-for-dataset', 'dcat:theme': 'http://eurovoc.europa.eu/561, http://eurovoc.europa.eu/273', 'dct:accessRights': 'Public', 'dct:conformsTo': 'http://example.com/standard', 'dct:created': '2024-03-04T18:46:05.045941', 'dct:creator': 'Your Organization or Name', 'dct:description': 'Dataset for wxt.wind.direction sensor data.', 'dct:identifier': '000048b02dd3c51f-wxt.wind.direction-vaisala-wxt536', 'dct:issued': '2024-03-04T18:46:05.045920', 'dct:language': 'en', 'dct:license': 'http://example.com/license', 'dct:modified': '2024-03-04T18:46:05.045943', 'dct:provenance': 'Generated from sensor network', 'dct:publisher': '{\"foaf:name\": \"Publisher Name\", \"foaf:homepage\": \"http://publisher-website.com\"}', 'dct:relation': '[\"http://example.com/related/resource1\", \"http://example.com/related/resource2\"]', 'dct:rights': 'http://creativecommons.org/licenses/by/4.0/', 'dct:source': 'Sensor Data Source or Origin', 'dct:spatial': 'lat: None, long: None', 'dct:subject': 'Weather Data, Environmental Data', 'dct:temporal': 'start: 2024-03-04T18:32:16.219946346Z, end: 2024-03-04T18:32:16.219946346Z', 'dct:title': 'wxt.wind.direction', 'dct:type': 'Dataset'}}]\n"
+     ]
+    }
+   ],
    "source": [
     "# Example search terms\n",
     "search_terms = [\"example\", \"test\"]\n",

--- a/pointofpresence/client_base.py
+++ b/pointofpresence/client_base.py
@@ -1,6 +1,6 @@
 # pointofpresence/client_base.py
-
 import requests
+from urllib.parse import urlparse
 
 
 class APIClientBase:
@@ -16,7 +16,8 @@ class APIClientBase:
         :param username: Username for authentication.
         :param password: Password for authentication.
         """
-        self.base_url = base_url.rstrip("/")
+        # Ensure the base URL has a valid protocol
+        self.base_url = self._ensure_protocol(base_url).rstrip("/")
         self.session = requests.Session()
         self.token = None
 
@@ -31,6 +32,20 @@ class APIClientBase:
             self._check_api_availability()
         if username and password:
             self.get_token(username, password)
+
+    @staticmethod
+    def _ensure_protocol(url: str) -> str:
+        """
+        Ensure the URL contains a valid protocol. If missing, prepend
+        'http://'.
+
+        :param url: The URL to validate.
+        :return: The URL with a protocol.
+        """
+        parsed_url = urlparse(url)
+        if not parsed_url.scheme:
+            return f"http://{url}"
+        return url
 
     def _check_api_availability(self):
         """

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -46,6 +46,36 @@ def test_init_no_auth(client_no_auth):
     assert "Authorization" not in client_no_auth.session.headers
 
 
+def test_base_url_missing_protocol():
+    """
+    Test initialization when base_url is missing the protocol.
+    Ensure 'http://' is prepended.
+    """
+    with patch.object(APIClientBase, "_check_api_availability"):
+        client = APIClientBase(base_url="api.example.com")
+        assert client.base_url == "http://api.example.com"
+
+
+def test_base_url_with_http_protocol():
+    """
+    Test initialization when base_url already includes 'http://'.
+    Ensure the base_url remains unchanged.
+    """
+    with patch.object(APIClientBase, "_check_api_availability"):
+        client = APIClientBase(base_url="http://api.example.com")
+        assert client.base_url == "http://api.example.com"
+
+
+def test_base_url_with_https_protocol():
+    """
+    Test initialization when base_url already includes 'https://'.
+    Ensure the base_url remains unchanged.
+    """
+    with patch.object(APIClientBase, "_check_api_availability"):
+        client = APIClientBase(base_url="https://api.example.com")
+        assert client.base_url == "https://api.example.com"
+
+
 @patch("pointofpresence.client_base.requests.Session.post")
 @patch.object(APIClientBase, "_check_api_availability")
 def test_get_token_success(mock_check_api, mock_post):
@@ -86,7 +116,6 @@ def test_get_token_failure(mock_check_api, mock_post):
     with pytest.raises(ValueError) as exc_info:
         client.get_token("user", "wrongpass")
 
-    # Adjusted assertion to match the actual error message
     assert "HTTP error occurred: Authentication failed" in str(exc_info.value)
     mock_post.assert_called_once_with(
         "https://api.example.com/token",


### PR DESCRIPTION
This pull request addresses **issue #1**, ensuring the `base_url` parameter in the `APIClientBase` class includes a protocol. If the protocol is missing, it defaults to `http://` to avoid connectivity errors.

#### **Changes:**
1. Added a private method `_ensure_protocol` in `APIClientBase` to validate and prepend `http://` if the protocol is missing.
2. Updated the `__init__` method to use `_ensure_protocol` during `base_url` initialization.
3. Modified existing tests to include this new functionality:
   - Added tests to validate correct handling of `base_url` with and without protocols.
4. Ensured all changes are PEP8 compliant and fully compatible with existing functionality.

#### **Closing Issue:**
Close #1