### PR TITLE
docs: Reminder for HTTP/HTTPS in API URL in tutorial

### DIFF
--- a/docs/point_of_presence_tutorial.ipynb
+++ b/docs/point_of_presence_tutorial.ipynb
@@ -88,14 +88,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from getpass import getpass\n",
     "\n",
     "# Prompt the user for API credentials\n",
-    "api_base_url = input(\"Enter the POP API base URL: \")\n",
+    "api_base_url = input(\"Enter the POP API base URL (include http:// or https://): \")\n",
     "api_username = input(\"Enter your POP API username: \")\n",
     "api_password = getpass(\"Enter your POP API password: \")"
    ]
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,18 +163,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Failed to register organization.\n",
-      "Error creating organization: Organization name already exists\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "organization_data = {\n",
     "    \"name\": \"example_org\",  # Unique identifier for the organization\n",
@@ -213,17 +204,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "All organizations: ['example_org', 'nsfsage', 'on-demand_fakequakes', 'earthscope_consortium', 'nasa', 'sage1', 'test_organization', 'usda']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# List all organizations without filtering\n",
     "try:\n",
@@ -243,17 +226,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Filtered organizations: ['example_org']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# List organizations with a filter by name\n",
     "try:\n",
@@ -683,17 +658,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Search Results: [{'id': '86a6103f-acbf-492b-8d3f-2c679561e8db', 'name': 'testing-deleteme-data-20240304-184605-metadata', 'title': 'testing_deleteme_data_20240304_184605.metadata', 'owner_org': 'nsfsage', 'notes': 'Automatically generated metadata for sensor data', 'resources': [], 'extras': {'dcat:accrualPeriodicity': 'http://purl.org/linked-data/sdmx/2009/code#freq-D', 'dcat:contactPoint': '{\"fn\": \"Contact Name\", \"hasEmail\": \"mailto:contact@example.com\"}', 'dcat:distribution': 'URL: http://ds2.datacollaboratory.org/sage/testing_deleteme_data_20240304_184605.metadata, MediaType: application/json', 'dcat:keyword': 'Wind, Aerology, Meteorology', 'dcat:landingPage': 'http://example.com/landing-page-for-dataset', 'dcat:theme': 'http://eurovoc.europa.eu/561, http://eurovoc.europa.eu/273', 'dct:accessRights': 'Public', 'dct:conformsTo': 'http://example.com/standard', 'dct:created': '2024-03-04T18:46:41.282756', 'dct:creator': 'Your Organization or Name', 'dct:description': 'Dataset for wxt.wind.direction sensor data.', 'dct:identifier': '000048b02dd3c51f-wxt.wind.direction-vaisala-wxt536', 'dct:issued': '2024-03-04T18:46:41.282738', 'dct:language': 'en', 'dct:license': 'http://example.com/license', 'dct:modified': '2024-03-04T18:46:41.282761', 'dct:provenance': 'Generated from sensor network', 'dct:publisher': '{\"foaf:name\": \"Publisher Name\", \"foaf:homepage\": \"http://publisher-website.com\"}', 'dct:relation': '[\"http://example.com/related/resource1\", \"http://example.com/related/resource2\"]', 'dct:rights': 'http://creativecommons.org/licenses/by/4.0/', 'dct:source': 'Sensor Data Source or Origin', 'dct:spatial': 'lat: None, long: None', 'dct:subject': 'Weather Data, Environmental Data', 'dct:temporal': 'start: 2024-03-04T18:46:31.119280646Z, end: 2024-03-04T18:46:31.119280646Z', 'dct:title': 'wxt.wind.direction', 'dct:type': 'Dataset'}}, {'id': 'a7c18dd5-0762-4d62-9e95-d224f12d528c', 'name': 'testing-deleteme-data-20240304-184529-metadata', 'title': 'testing_deleteme_data_20240304_184529.metadata', 'owner_org': 'nsfsage', 'notes': 'Automatically generated metadata for sensor data', 'resources': [], 'extras': {'dcat:accrualPeriodicity': 'http://purl.org/linked-data/sdmx/2009/code#freq-D', 'dcat:contactPoint': '{\"fn\": \"Contact Name\", \"hasEmail\": \"mailto:contact@example.com\"}', 'dcat:distribution': 'URL: http://ds2.datacollaboratory.org/sage/testing_deleteme_data_20240304_184529.metadata, MediaType: application/json', 'dcat:keyword': 'Wind, Aerology, Meteorology', 'dcat:landingPage': 'http://example.com/landing-page-for-dataset', 'dcat:theme': 'http://eurovoc.europa.eu/561, http://eurovoc.europa.eu/273', 'dct:accessRights': 'Public', 'dct:conformsTo': 'http://example.com/standard', 'dct:created': '2024-03-04T18:46:05.045941', 'dct:creator': 'Your Organization or Name', 'dct:description': 'Dataset for wxt.wind.direction sensor data.', 'dct:identifier': '000048b02dd3c51f-wxt.wind.direction-vaisala-wxt536', 'dct:issued': '2024-03-04T18:46:05.045920', 'dct:language': 'en', 'dct:license': 'http://example.com/license', 'dct:modified': '2024-03-04T18:46:05.045943', 'dct:provenance': 'Generated from sensor network', 'dct:publisher': '{\"foaf:name\": \"Publisher Name\", \"foaf:homepage\": \"http://publisher-website.com\"}', 'dct:relation': '[\"http://example.com/related/resource1\", \"http://example.com/related/resource2\"]', 'dct:rights': 'http://creativecommons.org/licenses/by/4.0/', 'dct:source': 'Sensor Data Source or Origin', 'dct:spatial': 'lat: None, long: None', 'dct:subject': 'Weather Data, Environmental Data', 'dct:temporal': 'start: 2024-03-04T18:32:16.219946346Z, end: 2024-03-04T18:32:16.219946346Z', 'dct:title': 'wxt.wind.direction', 'dct:type': 'Dataset'}}]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example search terms\n",
     "search_terms = [\"example\", \"test\"]\n",


### PR DESCRIPTION
In the `point_of_presence_tutorial.ipynb` tutorial, users are prompted to enter the base URL for the POP API. To prevent connection issues, the tutorial should remind users to include http:// or https:// at the beginning of the URL.

In the "Step 2: Enter API Credentials" section, added a note reminding users to include http:// or https:// in the api_base_url input.

CLose #2 