### PR TITLE
feat: Add server param to register_organization & update tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install pointofpresence
 
 ## Tutorial
 
-For a step-by-step guide on how to use the `pointofpresence` library, check out our comprehensive tutorial: [10 Minutes for a Point of Presence](https://github.com/sci-ndp/pop-py/blob/main/docs/point_of_presence_tutorial_0.4.0.ipynb).
+For a step-by-step guide on how to use the `pointofpresence` library, check out our comprehensive tutorial: [10 Minutes for a Point of Presence](https://github.com/sci-ndp/pop-py/blob/main/docs/point_of_presence_tutorial_0.5.2.ipynb).
 
 ## Running Tests
 

--- a/docs/point_of_presence_tutorial_0.5.1.ipynb
+++ b/docs/point_of_presence_tutorial_0.5.1.ipynb
@@ -1,0 +1,941 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 10 minutes for a Point of Presence (v0.5.1)\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/sci-ndp/pop-py/blob/main/docs/point_of_presence_tutorial_0.5.1.ipynb\" target=\"_parent\">\n",
+    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The **pointofpresence** library (Point of Presence) is a Python client designed to simplify interactions with a `POP API`. Concretely, this library handles the HTTP requests (GET, POST, PUT, DELETE) to the POP API and formats the results to make them more understandable for the user. This way, you can focus on working with the data directly without worrying about low-level API details.\n",
+    "\n",
+    "In this tutorial, we will cover the following points:\n",
+    "\n",
+    "1. [**Setting Up**](#1-setting-up): How to install and configure the `pointofpresence` library.\n",
+    "2. [**Initializing the Client**](#2-initializing-the-client): Creating and authenticating the client to connect with the POP API.\n",
+    "3. [**Managing Organizations**](#3-managing-organizations): An organization is how the POP API groups different resources. In this section, we will learn how to add and delete organizations.\n",
+    "\n",
+    "   3.1. [**Registering an Organization**](#31-registering-an-organization)\n",
+    "\n",
+    "   3.2. [**Listing Organizations**](#32-listing-organizations)\n",
+    "\n",
+    "   3.3. [**Deleting an Organization**](#33-deleting-an-organization)\n",
+    "\n",
+    "4. [**Working with Resources**](#4-working-with-resources): Creating, updating, and deleting various types of resources.\n",
+    "   \n",
+    "   4.1 [**Working with Kafka Topics**](#41-working-with-kafka-topics): Managing resources specific to Kafka topics.\n",
+    "\n",
+    "   4.2 [**Working with S3 Resources**](#42-working-with-s3-resources): Managing resources stored in S3.\n",
+    "\n",
+    "   4.3 [**Working with URLs**](#43-working-with-urls): Managing URL-based resources.\n",
+    "\n",
+    "   4.4. [**Searching Resources**](#44-searching-resources)\n",
+    "\n",
+    "   4.5. [**Deleting Resources**](#45-deleting-resources)\n",
+    "\n",
+    "   4.6. [**Working with Kafka Connection Details**](#46-working-with-kafka-connection-details)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setting Up\n",
+    "\n",
+    "To start using the `pointofpresence` library in Google Colab, follow these steps:\n",
+    "\n",
+    "### Step 1: Install the Library\n",
+    "\n",
+    "If you haven't already installed `pointofpresence`, you can do so via pip. Run the following command in your terminal:\n",
+    "\n",
+    "```bash\n",
+    "pip install pointofpresence\n",
+    "```\n",
+    "\n",
+    "Or, run here the following cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install pointofpresence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or, if you're working in a virtual environment and have cloned the repository, you can install it by running the following command in the root folder:\n",
+    "\n",
+    "```bash\n",
+    "pip install -e .\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 2: Enter API Credentials\n",
+    "\n",
+    "To configure the client, you need either:\n",
+    "1. The base URL where the POP API is hosted, and valid username and password for authentication, **or**\n",
+    "2. A valid token for authentication.\n",
+    "\n",
+    "#### Option 1: Username and Password Authentication\n",
+    "\n",
+    "Use the following code to configure the client using your username and password:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from getpass import getpass\n",
+    "\n",
+    "# Prompt the user for API credentials\n",
+    "api_base_url = input(\"Enter the POP API base URL (include http:// or https://): \")\n",
+    "api_username = input(\"Enter your POP API username: \")\n",
+    "api_password = getpass(\"Enter your POP API password: \")\n",
+    "api_token=None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Option 2: Token-Based Authentication\n",
+    "\n",
+    "If you already have a token, you can use it directly instead of providing a username and password:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prompt the user for API credentials\n",
+    "api_base_url = input(\"Enter the POP API base URL (include http:// or https://): \")\n",
+    "api_token = input(\"Enter your POP API token: \")\n",
+    "api_username=None\n",
+    "api_password=None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Initializing the Client\n",
+    "\n",
+    "Now that you have the required credentials, you can import and configure the `pointofpresence` client:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pointofpresence import APIClient\n",
+    "\n",
+    "# Initialize the API client\n",
+    "client = APIClient(base_url=api_base_url,\n",
+    "                   username=api_username,\n",
+    "                   password=api_password,\n",
+    "                   token=api_token)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your client is now configured and ready to interact with the POP API. In the next sections, we will explore how to use this client to manage organizations, resources, and more."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Managing Organizations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the POP API, organizations are logical groupings that help categorize and manage resources. You can think of an organization as a directory, and a resources as a file within it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.1. Registering an Organization\n",
+    "\n",
+    "You can create an organization using the `register_organization` method. This method requires a dictionary as input, with the following fields:\n",
+    "\n",
+    "- **name**: A unique identifier for the organization (must be distinct from existing organizations).\n",
+    "- **title**: The display name of the organization, which will appear in user interfaces.\n",
+    "- **description**: An optional field to describe the purpose or nature of the organization.\n",
+    "\n",
+    "Make sure to include these fields in your dictionary when registering a new organization.\n",
+    "\n",
+    "#### Example: Registering an Organization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "organization_data = {\n",
+    "    \"name\": \"example_org\",  # Unique identifier for the organization\n",
+    "    \"title\": \"Example Organization\",  # Display name for the organization\n",
+    "    \"description\": \"This organization groups datasets for project X.\"\n",
+    "}\n",
+    "\n",
+    "# Call the register_organization method to create the organization\n",
+    "try:\n",
+    "    response = client.register_organization(organization_data)\n",
+    "    print(\"Organization registered successfully with ID:\", response[\"id\"])\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to register organization.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2. Listing Organizations\n",
+    "\n",
+    "The `list_organizations` method allows you to retrieve the name of registered organizations in the POP API. This is useful for quickly identifying the available organizations.\n",
+    "\n",
+    "The method accepts an optional filtering parameter:\n",
+    "\n",
+    "- **name** (optional): A partial string to filter the organization names. The filtering is case-insensitive.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example: Listing All Organizations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List all organizations without filtering\n",
+    "try:\n",
+    "    all_organizations = client.list_organizations()\n",
+    "    print(\"All organizations:\", all_organizations)\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to retrieve organizations.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example: Listing Organizations with a Filter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List organizations with a filter by name\n",
+    "try:\n",
+    "    filtered_organizations = client.list_organizations(name=\"example\")\n",
+    "    print(\"Filtered organizations:\", filtered_organizations)\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to retrieve filtered organizations.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.3. Deleting an Organization\n",
+    "\n",
+    "You can delete an existing organization using the `delete_organization` method. This method will remove an organization and **all associated resources**.\n",
+    "\n",
+    "#### Example: Deleting an Organization\n",
+    "\n",
+    "Here's an example of how to delete an organization. In this example, we specify the name of the organization we want to delete:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Specify the name of the organization to delete\n",
+    "organization_name = \"example_org\"\n",
+    "\n",
+    "# Call the delete_organization method to remove the organization\n",
+    "try:\n",
+    "    response = client.delete_organization(organization_name)\n",
+    "    print(\"Organization deleted successfully:\", response[\"message\"])\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to delete organization.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Working with Resources\n",
+    "\n",
+    "In the POP API, a resource is a link to a specific data source along with a set of metadata associated with that source. Currently, you can register three types of resources:\n",
+    "\n",
+    "- **Kafka topics**: For managing data streams within Kafka.\n",
+    "- **S3 repository links**: For referencing data stored in Amazon S3 or similar storage services.\n",
+    "- **URL links to other data sources**: For linking to external data sources through a standard URL.\n",
+    "\n",
+    "Each resource type allows you to define the location and metadata of a specific dataset, making it easier to organize and manage data access.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1 Working with Kafka Topics\n",
+    "\n",
+    "The `register_kafka_topic` method requires a dictionary as an argument, which must contain the following fields:\n",
+    "\n",
+    "- **dataset_name**: A unique name for the dataset you are updating.\n",
+    "- **dataset_title**: The title for the dataset.\n",
+    "- **owner_org**: The name of the organization to which the dataset belongs.\n",
+    "- **kafka_topic**: The name of the Kafka topic.\n",
+    "- **kafka_host**: The host of the Kafka server.\n",
+    "- **kafka_port**: The port of the Kafka server.\n",
+    "- **dataset_description** (optional): A description of the dataset.\n",
+    "- **extras** (optional): Additional metadata in key-value format to include with the dataset.\n",
+    "- **mapping** (optional): Mapping information for selecting and renaming fields to send.\n",
+    "- **processing** (optional): Information on how to process the dataset.\n",
+    "\n",
+    "Make sure to include the required fields in your dictionary when calling this method to successfully update a Kafka topic.\n",
+    "\n",
+    "#### Example: Registering a Kafka Topic\n",
+    "\n",
+    "Here's an example of how to register a Kafka topic with all the required and optional fields:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the payload data for the Kafka topic registration\n",
+    "data = {\n",
+    "    \"dataset_name\": \"example_kafka_dataset_3\",\n",
+    "    \"dataset_title\": \"Example Kafka Dataset\",\n",
+    "    \"owner_org\": \"example_org\",\n",
+    "    \"kafka_topic\": \"example_topic\",\n",
+    "    \"kafka_host\": \"kafka_host\",\n",
+    "    \"kafka_port\": \"9092\",\n",
+    "    \"dataset_description\": \"This is a sample Kafka dataset.\",\n",
+    "    \"extras\": {\"key1\": \"value1\", \"key2\": \"value2\"},\n",
+    "    \"mapping\": {\"field1\": \"mapped_field1\", \"field2\": \"mapped_field2\"},\n",
+    "    \"processing\": {\"data_key\": \"data\", \"info_key\": \"info\"}\n",
+    "}\n",
+    "\n",
+    "# Call the register_kafka_topic method to add the Kafka topic\n",
+    "try:\n",
+    "    response = client.register_kafka_topic(data)\n",
+    "    print(\"Kafka topic registered successfully with ID:\", response[\"id\"])\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to register Kafka topic.\")\n",
+    "    print(f\"{e}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can update an existing Kafka topic by using the `update_kafka_topic` method. The fields that can be updated are the following:\n",
+    "\n",
+    "- **dataset_name** (optional): The unique name of the dataset.\n",
+    "- **dataset_title** (optional): The title of the dataset.\n",
+    "- **owner_org** (optional): The ID of the organization that owns the dataset.\n",
+    "- **kafka_topic** (optional): The name of the Kafka topic.\n",
+    "- **kafka_host** (optional): The host of the Kafka server.\n",
+    "- **kafka_port** (optional): The port of the Kafka server.\n",
+    "- **dataset_description** (optional): A description of the dataset.\n",
+    "- **extras** (optional): Additional metadata in key-value format.\n",
+    "- **mapping** (optional): Mapping information for structuring the dataset.\n",
+    "- **processing** (optional): Processing details for the dataset.\n",
+    "\n",
+    "### Example: Updating a Kafka Topic\n",
+    "\n",
+    "Here's an example of how to update an existing Kafka topic. In this example, we modify the `dataset_name` and `kafka_topic` fields:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the payload data for updating the Kafka topic\n",
+    "update_data = {\n",
+    "    \"dataset_name\": \"example_kafka_dataset_3\",\n",
+    "    \"kafka_topic\": \"example_topic_updated\"\n",
+    "}\n",
+    "\n",
+    "# Specify the dataset ID of the Kafka topic to update\n",
+    "dataset_id = \"64d34019-21ef-41ac-82c7-91d86fbc5a8c\"\n",
+    "\n",
+    "# Call the update_kafka_topic method to modify the Kafka topic\n",
+    "try:\n",
+    "    response = client.update_kafka_topic(dataset_id, update_data)\n",
+    "    print(\"Kafka topic updated successfully:\", response[\"message\"])\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to update Kafka topic.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2 Working with S3 Resources\n",
+    "\n",
+    "An S3 resource represents a reference or link to data stored in an S3 (Simple Storage Service) bucket.\n",
+    "\n",
+    "You can register an S3 resource using the `register_s3_link` method. When registering an S3 resource, ensure the following fields are included in input dictionary argument:\n",
+    "\n",
+    "- **resource_name**: A unique identifier for the S3 resource.\n",
+    "- **resource_title**: The title of the S3 resource.\n",
+    "- **owner_org**: The ID of the organization to which the resource belongs.\n",
+    "- **resource_s3**: The S3 URL of the resource (e.g., `\"s3://bucket-name/object-key\"`).\n",
+    "- **notes** (optional): Additional notes describing the resource.\n",
+    "- **extras** (optional): Additional metadata in key-value format associated with the resource.\n",
+    "\n",
+    "#### Example: Registering an S3 Resource Link\n",
+    "\n",
+    "Here’s an example of how to register an S3 resource link with both required and optional fields:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the payload data for the S3 resource link registration\n",
+    "data = {\n",
+    "    \"resource_name\": \"example_s3_resource_2\",\n",
+    "    \"resource_title\": \"Example S3 Resource\",\n",
+    "    \"owner_org\": \"example_org\",\n",
+    "    \"resource_s3\": \"s3://bucket-name/object-key\",\n",
+    "    \"notes\": \"This is a sample S3 resource.\",\n",
+    "    \"extras\": {\"key1\": \"value1\", \"key2\": \"value2\"}\n",
+    "}\n",
+    "\n",
+    "# Call the register_s3_link method to add the S3 resource link\n",
+    "try:\n",
+    "    response = client.register_s3_link(data)\n",
+    "    print(\"S3 resource link registered successfully with ID:\", response[\"id\"])\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to register S3 resource link.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can update an existing S3 resource using the `update_s3_resource` method providing any of the following fields in the input dict. These fields will overwrite the existing values for the specified resource:\n",
+    "\n",
+    "- **resource_name** (optional): The unique name of the resource.\n",
+    "- **resource_title** (optional): The title of the resource.\n",
+    "- **owner_org** (optional): The ID of the organization that owns the resource.\n",
+    "- **resource_s3** (optional): The S3 URL of the resource.\n",
+    "- **notes** (optional): Additional notes about the resource.\n",
+    "- **extras** (optional): Additional metadata as key-value pairs.\n",
+    "\n",
+    "### Example: Updating an S3 Resource\n",
+    "\n",
+    "Here's an example of how to update an existing S3 resource. In this example, we modify the `resource_name` and `resource_s3` fields:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the payload data for updating the S3 resource\n",
+    "update_data = {\n",
+    "    \"resource_name\": \"updated_resource_name\",\n",
+    "    \"resource_s3\": \"http://new-s3-url.com/resource\"\n",
+    "}\n",
+    "\n",
+    "# Specify the resource ID of the S3 resource to update\n",
+    "resource_id = \"e6d2c2a2-dcd7-4780-8385-1ab436798578\"\n",
+    "\n",
+    "# Call the update_s3_resource method to modify the S3 resource\n",
+    "try:\n",
+    "    response = client.update_s3_resource(resource_id, update_data)\n",
+    "    print(\"S3 resource updated successfully:\", response[\"message\"])\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to update S3 resource.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.3 Working with URLs\n",
+    "\n",
+    "You can register a URL resource by using the `register_url` method. The input data dictionary must contain the following fields:\n",
+    "\n",
+    "- **resource_name**: A unique name for the resource you are creating.\n",
+    "- **resource_title**: The title for the resource.\n",
+    "- **owner_org**: The ID of the organization to which the resource belongs.\n",
+    "- **resource_url**: The URL of the resource.\n",
+    "- **file_type**: The type of the file (`stream`, `CSV`, `TXT`, `JSON`, `NetCDF`).\n",
+    "- **notes** (optional): Additional notes about the resource.\n",
+    "- **extras** (optional): Additional metadata as key-value pairs to include with the resource package.\n",
+    "- **mapping** (optional): Mapping information for structuring and renaming fields.\n",
+    "- **processing** (optional): Processing details specific to the selected file type.\n",
+    "\n",
+    "### File Type-Specific Processing Information (Optional)\n",
+    "\n",
+    "For the `processing` field, ensure the structure matches the selected `file_type`. Here’s a breakdown for each type:\n",
+    "\n",
+    "1. **Stream**:\n",
+    "    ```json\n",
+    "    \"processing\": {\n",
+    "        \"refresh_rate\": \"5 seconds\",\n",
+    "        \"data_key\": \"results\"\n",
+    "    }\n",
+    "    ```\n",
+    "\n",
+    "2. **CSV**:\n",
+    "    ```json\n",
+    "    \"processing\": {\n",
+    "        \"delimiter\": \",\",\n",
+    "        \"header_line\": 1,\n",
+    "        \"start_line\": 2,\n",
+    "        \"comment_char\": \"#\"\n",
+    "    }\n",
+    "    ```\n",
+    "\n",
+    "3. **TXT**:\n",
+    "    ```json\n",
+    "    \"processing\": {\n",
+    "        \"delimiter\": \"\\t\",\n",
+    "        \"header_line\": 1,\n",
+    "        \"start_line\": 2\n",
+    "    }\n",
+    "    ```\n",
+    "\n",
+    "4. **JSON**:\n",
+    "    ```json\n",
+    "    \"processing\": {\n",
+    "        \"info_key\": \"count\",\n",
+    "        \"additional_key\": \"metadata\",\n",
+    "        \"data_key\": \"results\"\n",
+    "    }\n",
+    "    ```\n",
+    "\n",
+    "5. **NetCDF**:\n",
+    "    ```json\n",
+    "    \"processing\": {\n",
+    "        \"group\": \"group_name\"\n",
+    "    }\n",
+    "    ```\n",
+    "\n",
+    "### Example: Registering a URL Resource\n",
+    "\n",
+    "Here’s an example showing how to register a URL resource using the `register_url` method, along with the required fields and optional metadata:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the payload data for the URL resource registration\n",
+    "data = {\n",
+    "    \"resource_name\": \"example_url_resource_3\",\n",
+    "    \"resource_title\": \"Example URL Resource\",\n",
+    "    \"owner_org\": \"example_org\",\n",
+    "    \"resource_url\": \"http://example.com/data.csv\",\n",
+    "    \"file_type\": \"CSV\",\n",
+    "    \"notes\": \"This is a sample URL resource.\",\n",
+    "    \"extras\": {\"extra_source\": \"external\", \"extra_author\": \"data_provider\"},\n",
+    "    \"mapping\": {\"field1\": \"mapped_field1\", \"field2\": \"mapped_field2\"},\n",
+    "    \"processing\": {\n",
+    "        \"delimiter\": \",\",\n",
+    "        \"header_line\": 1,\n",
+    "        \"start_line\": 2,\n",
+    "        \"comment_char\": \"#\"\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "# Call the register_url method to add the URL resource\n",
+    "try:\n",
+    "    response = client.register_url(data)\n",
+    "    print(\"URL resource registered successfully with ID:\", response[\"id\"])\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to register URL resource.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can update an existing URL resource using the `update_url_resource` method providing any of the following fields in the input data dictionary:\n",
+    "\n",
+    "- **resource_name** (optional): The unique name of the resource.\n",
+    "- **resource_title** (optional): The title of the resource.\n",
+    "- **owner_org** (optional): The ID of the organization that owns the resource.\n",
+    "- **resource_url** (optional): The URL of the resource.\n",
+    "- **file_type** (optional): The type of the file (`stream`, `CSV`, `TXT`, `JSON`, `NetCDF`).\n",
+    "- **notes** (optional): Additional notes about the resource.\n",
+    "- **extras** (optional): Additional metadata as key-value pairs.\n",
+    "- **mapping** (optional): Mapping information for structuring and renaming fields.\n",
+    "- **processing** (optional): Processing details specific to the selected `file_type`.\n",
+    "\n",
+    "### Example: Updating a URL Resource\n",
+    "\n",
+    "Here's an example of how to update an existing URL resource. In this example, we modify the `resource_name`, `resource_title`, and `resource_url` fields:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the payload data for updating the URL resource\n",
+    "update_data = {\n",
+    "    \"resource_name\": \"example_resource_name\",\n",
+    "    \"resource_title\": \"Example Resource Title\",\n",
+    "    \"owner_org\": \"example_org_id\",\n",
+    "    \"resource_url\": \"http://example.com/resource\",\n",
+    "    \"file_type\": \"CSV\",\n",
+    "    \"notes\": \"Additional notes about the resource.\",\n",
+    "    \"extras\": {\"key1\": \"value1\", \"key2\": \"value2\"},\n",
+    "    \"mapping\": {\"field1\": \"mapping1\", \"field2\": \"mapping2\"},\n",
+    "    \"processing\": {\n",
+    "        \"delimiter\": \",\", \"header_line\": 1, \"start_line\": 2,\n",
+    "        \"comment_char\": \"#\"\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "# Specify the resource ID of the URL resource to update\n",
+    "resource_id = \"12345678-abcd-efgh-ijkl-1234567890ab\"\n",
+    "\n",
+    "# Call the update_url_resource method to modify the URL resource\n",
+    "try:\n",
+    "    response = client.update_url_resource(resource_id, update_data)\n",
+    "    print(\"URL resource updated successfully:\", response[\"message\"])\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to update URL resource.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.4. Searching Resources"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `search_datasets` function allows users to search for datasets across local or global servers. This function supports both global searches (searching terms across all fields) and key-specific searches (searching terms within specific fields). Users can combine global and key-specific searches in a single query.\n",
+    "\n",
+    "### Parameters\n",
+    "\n",
+    "- **`terms`** *(List[str], required)*:  \n",
+    "  A list of keywords to search within dataset titles, descriptions, or other fields.  \n",
+    "\n",
+    "- **`keys`** *(List[Optional[str]], optional)*:  \n",
+    "  An optional list of keys specifying the fields to search for each corresponding term.  \n",
+    "  - If `keys` is omitted, all `terms` are searched globally.  \n",
+    "  - If `keys[i]` is `None`, the corresponding `terms[i]` is searched globally.  \n",
+    "  - If `keys[i]` specifies a particular field, the corresponding `terms[i]` is searched within that field.  \n",
+    "\n",
+    "- **`server`** *(Literal['local', 'global'], optional)*:  \n",
+    "  Specifies which server to query for the datasets. Defaults to `'local'`.\n",
+    "\n",
+    "### Examples\n",
+    "\n",
+    "#### Global Search (Default Behavior)\n",
+    "Search for terms globally across all fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example search terms\n",
+    "search_terms = [\"example\", \"test\"]\n",
+    "\n",
+    "# Perform search on local server\n",
+    "results = client.search_datasets(terms=search_terms, server=\"local\")\n",
+    "\n",
+    "# Display results\n",
+    "print(\"Search Results:\", results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Key-Specific Search\n",
+    "Search for terms within specific fields using the `keys` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example search terms and corresponding keys\n",
+    "search_terms = [\"example\", \"temperature\"]\n",
+    "search_keys = [\"description\", \"extras.key1\"]\n",
+    "\n",
+    "# Perform key-specific search on local server\n",
+    "results = client.search_datasets(terms=search_terms, keys=search_keys, server=\"local\")\n",
+    "\n",
+    "# Display results\n",
+    "print(\"Search Results:\", results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Mixed Global and Key-Specific Search\n",
+    "Combine global and key-specific searches in a single query."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example with mixed global and key-specific search\n",
+    "search_terms = [\"example\", \"temperature\"]\n",
+    "search_keys = [None, \"extras.key1\"]  # Global search for \"example\", specific search for \"temperature\"\n",
+    "\n",
+    "# Perform mixed search\n",
+    "results = client.search_datasets(terms=search_terms, keys=search_keys, server=\"local\")\n",
+    "\n",
+    "# Display results\n",
+    "print(\"Search Results:\", results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Error Handling for Invalid Input\n",
+    "An exception is raised if the number of terms does not match the number of keys."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mismatched terms and keys\n",
+    "search_terms = [\"example\", \"temperature\"]\n",
+    "search_keys = [\"description\"]  # Missing key for second term\n",
+    "\n",
+    "try:\n",
+    "    results = client.search_datasets(terms=search_terms, keys=search_keys, server=\"local\")\n",
+    "except ValueError as e:\n",
+    "    print(f\"Error: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Notes\n",
+    "\n",
+    "1. If the `keys` parameter is not provided, the function behaves as it did previously, performing a global search for all terms.\n",
+    "2. The new `keys` functionality enables more precise searches, particularly useful when working with datasets that contain detailed metadata or custom fields.\n",
+    "3. The server parameter determines whether the search is performed on local datasets (`'local'`) or across all federated datasets (`'global'`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.5. Deleting Resources\n",
+    "\n",
+    "You can delete a resource in two ways:\n",
+    "\n",
+    "1. By specifying the **resource ID** with the `delete_resource_by_id` method.\n",
+    "2. By specifying the **resource name** with the `delete_resource_by_name` method.\n",
+    "\n",
+    "These methods allow you to remove resources from CKAN either by their unique identifier (ID) or by their name, making it easier to manage your resources.\n",
+    "\n",
+    "### Example: Deleting a Resource by ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Specify the ID of the resource to delete\n",
+    "# resource_id = \"example_id\"\n",
+    "resource_id = \"0c97be99-2bf8-4577-80e4-751d304db8f9\"\n",
+    "\n",
+    "# Call the delete_resource_by_id method to remove the resource\n",
+    "try:\n",
+    "    response = client.delete_resource_by_id(resource_id)\n",
+    "    print(\"Resource deleted successfully:\", response[\"message\"])\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to delete resource by ID.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example: Deleting a Resource by Name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Specify the name of the resource to delete\n",
+    "resource_name = \"example_url_resource_3\"\n",
+    "\n",
+    "# Call the delete_resource_by_name method to remove the resource\n",
+    "try:\n",
+    "    response = client.delete_resource_by_name(resource_name)\n",
+    "    print(\"Resource deleted successfully:\", response[\"message\"])\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to delete resource by name.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.6 Working with Kafka Connection Details\n",
+    "\n",
+    "We can retrieve the connection details for Kafka connection. This includes the Kafka host, port, and connection status.\n",
+    "\n",
+    "The following steps demonstrate how to make a request to the endpoint and interpret the response.\n",
+    "\n",
+    "#### Example Code\n",
+    "\n",
+    "Run the following code cell to get Kafka connection details:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    response = client.get_kafka_details()\n",
+    "    print(\"Kafka details:\", response)\n",
+    "except ValueError as e:\n",
+    "    print(\"Failed to get the Kafka details.\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Expected Output\n",
+    "\n",
+    "The output will display the Kafka connection details in the following format:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"kafka_host\": \"localhost\",\n",
+    "    \"kafka_port\": 9092,\n",
+    "    \"kafka_connection\": true\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Make sure the Kafka environment is configured correctly for the endpoint to return accurate details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/point_of_presence_tutorial_0.5.2.ipynb
+++ b/docs/point_of_presence_tutorial_0.5.2.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 10 minutes for a Point of Presence (v0.5.1)\n",
+    "# 10 minutes for a Point of Presence (v0.5.2)\n",
     "\n",
     "<a href=\"https://colab.research.google.com/sci-ndp/pop-py/blob/main/docs/point_of_presence_tutorial_0.5.1.ipynb\" target=\"_parent\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
@@ -192,7 +192,11 @@
     "- **title**: The display name of the organization, which will appear in user interfaces.\n",
     "- **description**: An optional field to describe the purpose or nature of the organization.\n",
     "\n",
-    "Make sure to include these fields in your dictionary when registering a new organization.\n",
+    "Additionally, you may specify an optional parameter:\n",
+    "\n",
+    "- **server** *(optional)*: Indicates which CKAN instance to use for registration. Allowed values are:\n",
+    "  - `\"local\"` *(default)*: Uses the local CKAN instance.\n",
+    "  - `\"pre_ckan\"`: Uses the pre-CKAN instance.\n",
     "\n",
     "#### Example: Registering an Organization"
    ]
@@ -211,7 +215,7 @@
     "\n",
     "# Call the register_organization method to create the organization\n",
     "try:\n",
-    "    response = client.register_organization(organization_data)\n",
+    "    response = client.register_organization(organization_data, server=\"local\")\n",
     "    print(\"Organization registered successfully with ID:\", response[\"id\"])\n",
     "except ValueError as e:\n",
     "    print(\"Failed to register organization.\")\n",
@@ -226,9 +230,13 @@
     "\n",
     "The `list_organizations` method allows you to retrieve the name of registered organizations in the POP API. This is useful for quickly identifying the available organizations.\n",
     "\n",
-    "The method accepts an optional filtering parameter:\n",
+    "The method accepts an optional filtering parameter and the server selection:\n",
     "\n",
-    "- **name** (optional): A partial string to filter the organization names. The filtering is case-insensitive.\n"
+    "- **name** *(optional)*: A partial string to filter the organization names. The filtering is case-insensitive.\n",
+    "- **server** *(optional)*: Indicates which CKAN instance to use for registration. Allowed values are:\n",
+    "  - `\"local\"` : Uses the local CKAN instance.\n",
+    "  - `\"pre_ckan\"`: Uses the pre-CKAN instance.\n",
+    "  - `\"global\"` (default): Use the globan CKAN instance.\n"
    ]
   },
   {
@@ -246,7 +254,7 @@
    "source": [
     "# List all organizations without filtering\n",
     "try:\n",
-    "    all_organizations = client.list_organizations()\n",
+    "    all_organizations = client.list_organizations(server=\"local\")\n",
     "    print(\"All organizations:\", all_organizations)\n",
     "except ValueError as e:\n",
     "    print(\"Failed to retrieve organizations.\")\n",
@@ -268,7 +276,7 @@
    "source": [
     "# List organizations with a filter by name\n",
     "try:\n",
-    "    filtered_organizations = client.list_organizations(name=\"example\")\n",
+    "    filtered_organizations = client.list_organizations(name=\"example\", server=\"local\")\n",
     "    print(\"Filtered organizations:\", filtered_organizations)\n",
     "except ValueError as e:\n",
     "    print(\"Failed to retrieve filtered organizations.\")\n",
@@ -281,7 +289,15 @@
    "source": [
     "### 3.3. Deleting an Organization\n",
     "\n",
-    "You can delete an existing organization using the `delete_organization` method. This method will remove an organization and **all associated resources**.\n",
+    "You can delete an existing organization using the `delete_organization` method. This method requires the parameter `organization_name`, which specifies the name\n",
+    "of the organization to be deleted. It will remove the organization and\n",
+    "all associated resources.\n",
+    "\n",
+    "Additionally, you may specify an optional parameter:\n",
+    "\n",
+    "- **server** *(optional)*: Indicates which CKAN instance to use for registration. Allowed values are:\n",
+    "  - `\"local\"` *(default)*: Uses the local CKAN instance.\n",
+    "  - `\"pre_ckan\"`: Uses the pre-CKAN instance.\n",
     "\n",
     "#### Example: Deleting an Organization\n",
     "\n",
@@ -299,7 +315,7 @@
     "\n",
     "# Call the delete_organization method to remove the organization\n",
     "try:\n",
-    "    response = client.delete_organization(organization_name)\n",
+    "    response = client.delete_organization(organization_name, server=\"local\")\n",
     "    print(\"Organization deleted successfully:\", response[\"message\"])\n",
     "except ValueError as e:\n",
     "    print(\"Failed to delete organization.\")\n",
@@ -318,7 +334,14 @@
     "- **S3 repository links**: For referencing data stored in Amazon S3 or similar storage services.\n",
     "- **URL links to other data sources**: For linking to external data sources through a standard URL.\n",
     "\n",
-    "Each resource type allows you to define the location and metadata of a specific dataset, making it easier to organize and manage data access.\n"
+    "Each resource type allows you to define the location and metadata of a specific dataset, making it easier to organize and manage data access.\n",
+    "\n",
+    "Throughout this section, all functionalities include an optional parameter, `server`, which allows you to select the server on which the operation is performed.  \n",
+    "\n",
+    "- For **registration, updating, and deletion** operations, the `server` parameter can only be `\"local\"` or `\"pre-ckan\"`, and it defaults to `\"local\"`.  \n",
+    "- For **search functions**, the `server` parameter can also be `\"global\"`, and it defaults to `\"global\"`.\n",
+    "\n",
+    "In the provided examples, we have not explicitly included this parameter, so the default values are being used."
    ]
   },
   {

--- a/pointofpresence/register_organization_method.py
+++ b/pointofpresence/register_organization_method.py
@@ -5,17 +5,20 @@ from requests.exceptions import HTTPError
 class APIClientOrganizationRegister(APIClientBase):
     """Extension of APIClientBase with organization registration method."""
 
-    def register_organization(self, data):
+    def register_organization(self, data, server="local"):
         """
         Register a new organization by making a POST request.
 
         :param data: Data for the organization.
+        :param server: CKAN instance
+            ("local" or "pre_ckan"). Defaults to "local".
         :return: Response JSON data with the organization ID and message.
         :raises ValueError: If the registration fails or name already exists.
         """
         url = f"{self.base_url}/organization"
+        params = {"server": server}
         try:
-            response = self.session.post(url, json=data)
+            response = self.session.post(url, json=data, params=params)
             response.raise_for_status()
             return response.json()
         except HTTPError as e:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open(os.path.join(here, "README.md"), "r", encoding="utf-8") as fh:
 
 setup(
     name="pointofpresence",
-    version="0.5.1",
+    version="0.5.2",
     author="Raul Bardaji, Saleem Slharir, Andreu Fornos, Philip Davis",
     author_email=(
         "rbardaji@gmail.com, saleem.alharir@utah.edu, andreu.fornos@utah.edu,"

--- a/tests/test_register_organization_method.py
+++ b/tests/test_register_organization_method.py
@@ -48,7 +48,9 @@ def test_register_organization_success(mock_check_api, mock_post, client):
     assert response["id"] == "305284e6-6338-4e13-b39b-e6efe9f1c45a"
     assert response["message"] == "Organization created successfully"
     mock_post.assert_called_once_with(
-        "https://api.example.com/organization", json=data
+        "https://api.example.com/organization",
+        json=data,
+        params={"server": "local"},
     )
 
 
@@ -86,7 +88,9 @@ def test_register_organization_name_exists(mock_check_api, mock_post, client):
         == "Error creating organization: Organization name already exists"
     )
     mock_post.assert_called_once_with(
-        "https://api.example.com/organization", json=data
+        "https://api.example.com/organization",
+        json=data,
+        params={"server": "local"},
     )
 
 
@@ -122,5 +126,7 @@ def test_register_organization_general_failure(
         exc_info.value
     )
     mock_post.assert_called_once_with(
-        "https://api.example.com/organization", json=data
+        "https://api.example.com/organization",
+        json=data,
+        params={"server": "local"},
     )


### PR DESCRIPTION
 This PR introduces support for the `server` parameter in the `register_organization` method, allowing users to specify the CKAN instance (`local` or `pre_ckan`). This aligns the client with recent API updates, ensuring explicit control over the target instance.  

Additionally, the tutorial notebook (`point_of_presence_tutorial_0.4.0.ipynb`) has been updated to reflect the changes introduced in version **0.5.1**, including:  
- Compatibility installation cell for Google Colab.  
- Addition of the `server` parameter in Kafka, URL, and S3 resource methods.  
- A new section covering the `advanced_search` method with an example.  

**Note:** Due to bugs identified in version **0.5.1**, a new version **0.5.2** has been created to address these issues.


Close #19
Close #18